### PR TITLE
fixes delete_all_revisions_of for Revisionair.Storage.Agent

### DIFF
--- a/lib/revisionair/storage/agent.ex
+++ b/lib/revisionair/storage/agent.ex
@@ -62,7 +62,8 @@ defmodule Revisionair.Storage.Agent do
 
   def delete_all_revisions_of(item_type, item_id, _opts) do
     Agent.update(__MODULE__, fn item_types ->
-      pop_in item_types, [item_type, item_id]
+      # returns a tuple with the deleted value and the new map
+      pop_in(item_types, [item_type, item_id]) |> elem(1)
     end)
     :ok
   end


### PR DESCRIPTION
Problem: 
- current impl. does not work if you want to continue using the store, because the new state of the agent is a tuple and not a map anymore

Solution:
- take the second element of the resulting tuple for new state